### PR TITLE
feat(m3fs): Add --pid host to client docker containers

### DIFF
--- a/pkg/3fs_client/tasks.go
+++ b/pkg/3fs_client/tasks.go
@@ -126,6 +126,7 @@ func (t *Create3FSClientServiceTask) Init(r *task.Runtime, logger log.Interface)
 					WorkDir:        workDir,
 					ExtraVolumes:   runContainerVolumes,
 					UseRdmaNetwork: true,
+					PidHost:        true,
 					ModelObjFunc: func(s *task.BaseStep) any {
 						return &model.FuseClient{
 							Name:           r.Services.Client.ContainerName,

--- a/pkg/external/docker.go
+++ b/pkg/external/docker.go
@@ -58,6 +58,7 @@ func (de *dockerExternal) GetContainer(name string) string {
 type RunArgs struct {
 	Image         string
 	HostNetwork   bool
+	PidHost       bool
 	Entrypoint    *string
 	Rm            *bool
 	Command       []string
@@ -96,6 +97,9 @@ func (de *dockerExternal) Run(ctx context.Context, args *RunArgs) (out string, e
 	}
 	if args.HostNetwork {
 		params = append(params, "--network", "host")
+	}
+	if args.PidHost {
+		params = append(params, "--pid", "host")
 	}
 	for key, val := range args.Envs {
 		params = append(params, "-e", fmt.Sprintf("%s=%s", key, val))

--- a/pkg/task/steps/3fs_steps.go
+++ b/pkg/task/steps/3fs_steps.go
@@ -387,6 +387,7 @@ type run3FSContainerStep struct {
 	serviceWorkDir string
 	extraVolumes   []*external.VolumeArgs
 	useRdmaNetwork bool
+	pidHost        bool
 	modelObjFunc   func(r *task.BaseStep) any
 }
 
@@ -428,6 +429,7 @@ func (s *run3FSContainerStep) Execute(ctx context.Context) error {
 		Image:         img,
 		Name:          &s.containerName,
 		HostNetwork:   true,
+		PidHost:       s.pidHost,
 		RestartPolicy: external.ContainerRestartPolicyUnlessStopped,
 		Privileged:    common.Pointer(true),
 		Ulimits: map[string]string{
@@ -505,6 +507,7 @@ type Run3FSContainerStepSetup struct {
 	WorkDir        string
 	ExtraVolumes   []*external.VolumeArgs
 	UseRdmaNetwork bool
+	PidHost        bool
 	ModelObjFunc   func(r *task.BaseStep) any
 	DeleteIfExists bool
 }
@@ -519,6 +522,7 @@ func NewRun3FSContainerStepFunc(setup *Run3FSContainerStepSetup) func() task.Ste
 			serviceWorkDir: setup.WorkDir,
 			extraVolumes:   setup.ExtraVolumes,
 			useRdmaNetwork: setup.UseRdmaNetwork,
+			pidHost:        setup.PidHost,
 			modelObjFunc:   setup.ModelObjFunc,
 			deleteIfExists: setup.DeleteIfExists,
 		}


### PR DESCRIPTION
There's a bug in 3FS itself that causes a race if you try to access two different files at exactly the same time.

A work around is to start the 3FS fuse client docker container with `--pid host`.

This PR does that. The only complexity is it avoids adding the flag to the other docker containers; only the fuse client is affected.

This is completely untested, but I wanted to be sure it's saved in git if we ever need it.

